### PR TITLE
Break circular ref for Assembler parent.

### DIFF
--- a/lib/Email/MIME/Kit/Assembler/Standard.pm
+++ b/lib/Email/MIME/Kit/Assembler/Standard.pm
@@ -31,6 +31,7 @@ sub BUILD {
 has parent => (
   is  => 'ro',
   isa => maybe_type(role_type('Email::MIME::Kit::Role::Assembler')),
+  weak_ref => 1,
 );
 
 has renderer => (


### PR DESCRIPTION
While doing some leak tracking; I found circular reference for `parent` attribute in 'Standard' assembler. Adding `weak_ref` to attribute fixed the leak I was seeing. All tests still pass.
