### PR TITLE
use a second attribute, not initializer, for obj-from-class setup

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Email-MIME-Kit
 
 {{$NEXT}}
+        - set up kit_reader and manifest_reader with a helper attribute instead
+          of the weird and rarely-seen Moose "initializer" system
 
 3.000004  2016-08-03 22:48:27-04:00 America/New_York
         - require a newer Email::MIME so we can rely on the header_raw method


### PR DESCRIPTION
We have some places where we want to be able to have the manifest
contain a class name, but the attribute contain an object built from
that.  Because the build object needs to have a reference back to
the kit, it can't be created entirely from coercion, as types are
not dependent on the attributes using them.

Instead, we insert a shim attribute that will store the seed of the
value to use.  There's no danger of someone passing a full object
into ->new, either, because it couldn't exist yet, because it would
need to already point back to the instance we're about to construct!